### PR TITLE
Import template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `import_template` command.
+
 ## 0.1.4 (2023-04-11)
 
 - Fix publishing to RailsBytes.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ file "config/anycable.yml", ERB.new(
 
 **NOTE:** By default, we assume that partials are stored next to the template's entry-point. Partials may have the "_" prefix and ".rb" or ".tt" suffixes.
 
+Ruby Bytes can also import a sub-template into your template. Simply use the `#import_template` helper in your template:
+
+```erb
+# subtemplate/_partial.rb
+say "Hello from subtemplate's partial!"
+
+# subtemplate/subtemplate.rb
+<%= include "partial" %>
+
+# template.rb
+<%= import_template("subtemplate/subtemplate.rb")>
+```
+
+Note that the full filename must be passed to the `#import_template` helper, including any file extension, unlike the `#include` helper. All templates within the subtemplate directory will consider that to be their root directory.
+
+
 ### Compiling templates
 
 You can compile a template by using the `rbytes` executable:

--- a/lib/ruby_bytes/compiler.rb
+++ b/lib/ruby_bytes/compiler.rb
@@ -32,6 +32,10 @@ module RubyBytes
       indented(render(File.read(resolve_path(path))), indent)
     end
 
+    def import_template(path, indent: 0)
+      indented(self.class.new(File.join(root, path)).render, indent)
+    end
+
     private
 
     PATH_CANDIDATES = [

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -67,6 +67,22 @@ class PartialLookupTest < RubyBytes::TestCase
   end
 end
 
+class IncludeTemplateTest < RubyBytes::TestCase
+  root File.join(__dir__, "templates/imports_template")
+
+  template <<~RUBY
+    <%= include "importer" %>
+  RUBY
+
+  def test_included_template
+    run_generator do |output|
+      assert_line_printed output, "Hello from the Root"
+      assert_line_printed output, "Hello from A template"
+      assert_line_printed output, "Hello from A partial"
+    end
+  end
+end
+
 class PromptTest < RubyBytes::TestCase
   template <<~RUBY
     if yes?("Mochtest du etwas trinken?")

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -122,7 +122,7 @@ class DummyRailsTest < RubyBytes::TestCase
     run_generator do |output|
       assert_line_printed(
         output,
-        "APP=robo-bytes"
+        "APP=robobytes"
       )
     end
   end

--- a/test/templates/imports_template/example_a/_a.rb.tt
+++ b/test/templates/imports_template/example_a/_a.rb.tt
@@ -1,0 +1,1 @@
+say "Hello from A partial!"

--- a/test/templates/imports_template/example_a/example_a.rb
+++ b/test/templates/imports_template/example_a/example_a.rb
@@ -1,0 +1,3 @@
+say "Hello from A template"
+
+<%= include "a.rb" %>

--- a/test/templates/imports_template/importer.rb
+++ b/test/templates/imports_template/importer.rb
@@ -1,0 +1,3 @@
+say "Hello from the Root"
+
+<%= import_template "example_a/example_a.rb" %>


### PR DESCRIPTION
## What is the purpose of this pull request?

Adds `import_template` command, as discussed in #2. (Resolves #2).

## What changes did you make? (overview)
* Added `import_template` method to `RubyBytes::Compiler`, which creates a new `Compiler` instance at the sub-template's path and renders it.
* The `DummyRailsTest` integration test was failing for me without any changes (I changed expected value from the `parameterize` method to `robobytes` rather than `robo-bytes`), I included that fix in a separate commit on this PR)

## Is there anything you'd like reviewers to focus on?

Does creating a new `Compiler` seem like the best approach (this certainly seems like the simplest)? 

Thor implements its `inside` command using a stack of destinations, pushing and popping onto/from that stack to handle different working directories without having to create new objects to contain the state change.

I'm happy with the simpler solution provided here - as far as I can see the main downside to this approach is extra object creation, but as I don't expect this to get used more than a handful of times per template, this seems like a reasonable tradeoff. Happy to reconsider if you feel differently, though.

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
